### PR TITLE
README.md markup fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
---------------------------------------------------------------------------------
-What is Jez Toolkit (JTK) Framework?
---------------------------------------------------------------------------------
 
-Jez Tookit (JTK) Framework is a framework designed for writing powerful applications
+What is Jez Toolkit (JTK) Framework?
+------------------------------------
+
+Jez Tookit (JTK) Framework is a framework designed for writing powerful applications  
 in C.
 
-Initially, the development of the library began within an other project, a
-compiler for Zen. Zen is a programming language currently under development
-at OneCube Software Solutions. We observed a need for a framework that could be
-reused in other projects, too. Therefore, we refactored the reusable components
-and called it Jez Toolkit (JTK).
+Initially, the development of the library began within an other project, a  
+compiler for Zen. Zen is a programming language currently under development  
+at OneCube Software Solutions. We observed a need for a framework that could be  
+reused in other projects, too. Therefore, we refactored the reusable components  
+and called it Jez Toolkit (JTK).  
 
-As of this version, JTK is quite unstable. It lacks detailed documentation and
-examples. We recommend you not to integrate it with your projects. We have
-published the framework only for the sake of testing it.
+As of this version, JTK is quite unstable. It lacks detailed documentation and  
+examples. We recommend you not to integrate it with your projects. We have  
+published the framework only for the sake of testing it.  
 
---------------------------------------------------------------------------------
+
 Installation
---------------------------------------------------------------------------------
+------------
 
 [Windows]
 
-1. For compiling JTK on Windows, you first need to install MSYS2. The steps required
-   to install MSYS2 are beyond the scope of this documentation. Although, you can find
-   tutorials on installing MSYS2 on the Internet.
-2. Extract the source code to any directory of your choice, for the sake of this
-   documentation we will refer this location as 'C:\jtk-1.0'.
-3. Change the directory to 'C:\jtk-1.0'.
+1. For compiling JTK on Windows, you first need to install MSYS2. The steps required  
+   to install MSYS2 are beyond the scope of this documentation. Although, you can find  
+   tutorials on installing MSYS2 on the Internet.  
+2. Extract the source code to any directory of your choice, for the sake of this  
+   documentation we will refer this location as 'C:\jtk-1.0'.  
+3. Change the directory to 'C:\jtk-1.0'.  
     ```
     cd 'C:/jtk-1.0'
     ```
-4. Create a temporary directory for compiling the source code. For the sake of this
+4. Create a temporary directory for compiling the source code. For the sake of this  
    documentation we will refer to this directory as 'build'.
    ```
    mkdir build
@@ -39,55 +39,60 @@ Installation
    ```
    cd build
    ```
-6. Invoke CMake to generate make files. In this documentation, we show the
-   commands to generate GNU Makefiles. You can easily generate other makefiles
+6. Invoke CMake to generate make files. In this documentation, we show the  
+   commands to generate GNU Makefiles. You can easily generate other makefiles  
    similarly.
    ```
    cmake .. -G 'MSYS Makefiles'
    ```
-7. Invoke the GNU Make program. The command may be different on your system,
+7. Invoke the GNU Make program. The command may be different on your system,  
    if you have not setup an alias.
    ```
    make
    ```
-   This should compile the framework. Archives and executable files should be
-   produced in your current working directory. You can link the library to
-   your project. As of this version, a plethora of warnings are generated.
+   This should compile the framework. Archives and executable files should be  
+   produced in your current working directory. You can link the library to  
+   your project. As of this version, a plethora of warnings are generated.  
    We are working to eradicate these warnings.
 
---------------------------------------------------------------------------------
 Structure of JTK
---------------------------------------------------------------------------------
+----------------
 
-The various components of JTK are grouped together under modules. Each module
-compiles into a library archive. As of version 1.0, there are three components.
+The various components of JTK are grouped together under modules. Each module  
+compiles into a library archive. As of version 1.0, there are three components.  
 
-[Core]
-The core module provides the basic necessities such as loggers, memory
-allocation/deallocation, string utilities, integer utilities, etc.
+### [Core]
+The core module provides the basic necessities such as loggers, memory  
+allocation/deallocation, string utilities, integer utilities, etc.  
 
-[Collection]
-This module consists of various data structures and algorithms, which include
+
+### [Collection]
+This module consists of various data structures and algorithms, which include  
 lists, maps, sets, bags, etc.
 
-[Unit]
-A module designed for writing unit tests.
 
-Further, each module is again divided into classes. Not that, a class in JTK
-simply refers to a group of functions which manipulate instances of a specific
-structure. For example, the TestCase class simply refers a group of functions
-which work on an instance of the jtk_TestCase_t structure.
+### [Unit]
+A module designed for writing unit tests.  
 
-Every component declared within JTK use the following name scheme:
+Further, each module is again divided into classes. Not that, a class in JTK  
+simply refers to a group of functions which manipulate instances of a specific  
+structure. For example, the TestCase class simply refers a group of functions  
+which work on an instance of the jtk_TestCase_t structure.  
+
+
+Every component declared within JTK use the following name scheme:  
+
     jtk_Class_function
-The name of a component is divided into three parts separated by an underscore:
-    * jtk - This prefix is added to all the components in JTK. We are simply
-      trying to simulate a name space (as in C++) or packages (as in Java).
-    * Class - The class in which the function belongs.
-    * function - The name of the function.
+
+The name of a component is divided into three parts separated by an underscore:  
+    * jtk - This prefix is added to all the components in JTK. We are simply  
+      trying to simulate a name space (as in C++) or packages (as in Java).  
+    * Class - The class in which the function belongs.  
+    * function - The name of the function.  
 
 Example (in Java):
 
+```
 class TestCase {
 
     ...
@@ -96,76 +101,76 @@ class TestCase {
         ...
     }
 }
+```
 
 The above class translate to the following snippet in C. It follows the naming
 scheme as described above.
 
+```
 bool jtk_TestCase_isSuccessful(jtk_TestCase_t* testCase) {
     ...
 }
+```
 
---------------------------------------------------------------------------------
 Style Guidelines
---------------------------------------------------------------------------------
+----------------
 
---------------------------------------------------------------------------------
-Files (relative to the root of the source code)
---------------------------------------------------------------------------------
+### Files (relative to the root of the source code)
 
-[example]
+
+#### [example]
 This directory consists of example programs. It is intended for beginners,
 intermidiate users, and advanced users. It showcases a variety of examples of
 using the framework.
 
-[include]
+#### [include]
 This directory consists of all the header files exported by the JTK Framework.
 
-[share]
+#### [share]
 This directory consists of misc files for tools such as pkg-config, etc.
 
-[source]
+#### [source]
 This directory consists of all the source files that is compiled into library
 archives.
 
-[test]
+#### [test]
 This directory consits of unit tests for the framework.
 
-[CMakeLists.txt]
+#### [CMakeLists.txt]
 The rules for compiling the library, unit tests, etc. Feed this file to CMake
 in order to generate make files. Currently, it is tested only for MinGW Make.
 
-[README.txt]
+#### [README.md]
 A brief document to get you started. A more detailed document is yet to be written.
 
---------------------------------------------------------------------------------
-Overload Suffixes
---------------------------------------------------------------------------------
 
-v - void pointer
-b - byte
-s - short
-i - integer
-l - long
-f - float
-d - double
-utf8 - uint8_t*
-z - boolean
-c - char
-cz - char*
+### Overload Suffixes
 
-Certain functions within the library are overloaded, that is, they perform the
-same operation but on different data types. Such functions share a same name
+
+ - v - void pointer
+ - b - byte
+ - s - short
+ - i - integer
+ - l - long
+ - f - float
+ - d - double
+ - utf8 - uint8_t*
+ - z - boolean
+ - c - char
+ - cz - char*
+
+Certain functions within the library are overloaded, that is, they perform the  
+same operation but on different data types. Such functions share a same name  
 with a unique suffix. The suffixes are listed above.
 
---------------------------------------------------------------------------------
-TODO.txt
---------------------------------------------------------------------------------
+
+### TODO.txt
+
 
 It lists all the features yet to be implemented by the framework.
 
---------------------------------------------------------------------------------
-License
---------------------------------------------------------------------------------
+
+## License
 
 Copyright 2018-2019 OneCube
 


### PR DESCRIPTION
Fixed lists, embedded code, and line breaks.  
hint: you can break a line (i.e., the equiv to the `<br />` tag) by ending a line with two spaces:

this line  
is broken up!

I don't know what editor you use, but for Notepad++, there's a really great markdown plugin, that helps tremendously.